### PR TITLE
add callback for metadata update

### DIFF
--- a/src/callbacks/SessionCallbacks.cc
+++ b/src/callbacks/SessionCallbacks.cc
@@ -126,6 +126,12 @@ void SessionCallbacks::end_of_track(sp_session* session) {
   }
 }
 
+void SessionCallbacks::metadata_updated(sp_session *session) {
+  if(Player::instance->nodeObject != nullptr) {
+    Player::instance->nodeObject->call(METADATA_UPDATED);
+  }
+}
+
 void SessionCallbacks::sendTimer(int sample_rate) {
   if( spotify::framesReceived / sample_rate > 0) {
     spotify::currentSecond++;

--- a/src/callbacks/SessionCallbacks.h
+++ b/src/callbacks/SessionCallbacks.h
@@ -38,6 +38,7 @@ public:
   static void rootPlaylistContainerLoaded(sp_playlistcontainer* spPlaylistContainer, void* userdata);
   static int music_delivery(sp_session *sess, const sp_audioformat *format, const void *frames, int num_frames);
   static void end_of_track(sp_session* session);
+  static void metadata_updated(sp_session *session);
   static void handleNotify(uv_async_t* handle, int status);
   static void init();
   static v8::Handle<v8::Function> loginCallback;

--- a/src/events.h
+++ b/src/events.h
@@ -31,4 +31,6 @@ THE SOFTWARE.
 #define SEARCH_COMPLETE "search_complete"
 #define ALBUMBROWSE_COMPLETE "albumbrowse_complete"
 #define ARTISTBROWSE_COMPLETE "artistbrowse_complete"
+#define METADATA_UPDATED "metadata_updated"
+
 #endif

--- a/src/objects/node/NodeSpotify.cc
+++ b/src/objects/node/NodeSpotify.cc
@@ -168,6 +168,7 @@ Handle<Value> NodeSpotify::getRememberedUser(Local<String> property, const Acces
 void NodeSpotify::init() {
   HandleScope scope;
   Handle<FunctionTemplate> constructorTemplate = NodeWrapped::init("Spotify");
+
   NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "login", login);
   NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "logout", logout);
   NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "getPlaylists", getPlaylists);

--- a/src/objects/spotify/Spotify.cc
+++ b/src/objects/spotify/Spotify.cc
@@ -60,6 +60,7 @@ sp_session* Spotify::createSession(SpotifyOptions options) {
   sessionCallbacks.logged_out = &SessionCallbacks::loggedOut;
   sessionCallbacks.music_delivery = &SessionCallbacks::music_delivery;
   sessionCallbacks.end_of_track = &SessionCallbacks::end_of_track;
+  sessionCallbacks.metadata_updated = &SessionCallbacks::metadata_updated;
 
   sessionConfig.api_version = SPOTIFY_API_VERSION;
   sessionConfig.cache_location = options.cacheFolder.c_str();


### PR DESCRIPTION
NodePlayer::play is both loading the track and immediately playing it, even if it might not be loaded yet.
Add a callback for metadata updates, so it is possible to retry playing the track.
