### PR TITLE
inboxPlaylist WIP. Works, but incorrectly follows the User.starredPlaylist pattern. Should be on PlaylistContainer instead?

### DIFF
--- a/src/objects/node/NodeSpotify.cc
+++ b/src/objects/node/NodeSpotify.cc
@@ -158,6 +158,13 @@ Handle<Value> NodeSpotify::getSessionUser(Local<String> property, const Accessor
   return scope.Close(nodeUser->getV8Object());
 }
 
+Handle<Value> NodeSpotify::getInboxPlaylist(Local<String> property, const AccessorInfo& info) {
+  HandleScope scope;
+  NodeSpotify* nodeSpotify = node::ObjectWrap::Unwrap<NodeSpotify>(info.Holder());
+  NodePlaylist* nodePlaylist = new NodePlaylist(nodeSpotify->spotify->inboxPlaylist());
+  return scope.Close(nodePlaylist->getV8Object());
+}
+
 Handle<Value> NodeSpotify::getConstants(Local<String> property, const AccessorInfo& info) {
   HandleScope scope;
   Local<Object> constants = Object::New();
@@ -198,6 +205,7 @@ void NodeSpotify::init() {
   constructorTemplate->InstanceTemplate()->SetAccessor(String::NewSymbol("sessionUser"), getSessionUser);
   constructorTemplate->InstanceTemplate()->SetAccessor(String::NewSymbol("playlistContainer"), getPlaylistContainer);
   constructorTemplate->InstanceTemplate()->SetAccessor(String::NewSymbol("constants"), getConstants);
+  constructorTemplate->InstanceTemplate()->SetAccessor(String::NewSymbol("inboxPlaylist"), getInboxPlaylist);
 
   constructor = Persistent<Function>::New(constructorTemplate->GetFunction());
   scope.Close(Undefined());

--- a/src/objects/node/NodeSpotify.h
+++ b/src/objects/node/NodeSpotify.h
@@ -18,6 +18,7 @@ public:
   static Handle<Value> getPlaylistContainer(Local<String> property, const AccessorInfo& info);
   static Handle<Value> getRememberedUser(Local<String> property, const AccessorInfo& info);
   static Handle<Value> getSessionUser(Local<String> property, const AccessorInfo& info);
+  static Handle<Value> getInboxPlaylist(Local<String> property, const AccessorInfo& info);
   static Handle<Value> createFromLink(const Arguments& args);
   static Handle<Value> getConstants(Local<String> property, const AccessorInfo& info);
   static Handle<Value> on(const Arguments& other);

--- a/src/objects/spotify/InboxPlaylist.h
+++ b/src/objects/spotify/InboxPlaylist.h
@@ -1,0 +1,12 @@
+#ifndef _INBOX_PLAYLIST_H
+#define _INBOX_PLAYLIST_H
+
+#include "Playlist.h"
+
+class InboxPlaylist : public Playlist {
+public:
+  InboxPlaylist(sp_playlist* _playlist) : Playlist(_playlist) {};
+  std::string name() { return "Inbox"; }
+};
+
+#endif

--- a/src/objects/spotify/Spotify.cc
+++ b/src/objects/spotify/Spotify.cc
@@ -85,3 +85,10 @@ std::shared_ptr<User> Spotify::sessionUser() {
   auto user = std::make_shared<User>(sp_session_user(session));
   return user;
 }
+
+std::shared_ptr<Playlist> Spotify::inboxPlaylist() {
+  std::shared_ptr<Playlist> playlist;
+  auto spotifyPlaylist = sp_session_inbox_create(session);
+  playlist = std::make_shared<InboxPlaylist>(spotifyPlaylist);
+  return playlist;
+}

--- a/src/objects/spotify/Spotify.h
+++ b/src/objects/spotify/Spotify.h
@@ -3,6 +3,7 @@
 
 #include "SpotifyOptions.h"
 #include "User.h"
+#include "InboxPlaylist.h"
 
 #include <libspotify/api.h>
 #include <string>
@@ -16,6 +17,7 @@ public:
   void logout();
   std::string rememberedUser();
   std::shared_ptr<User> sessionUser();
+  std::shared_ptr<Playlist> inboxPlaylist();
 private:
   sp_session* session;
   sp_session* createSession(SpotifyOptions options);


### PR DESCRIPTION
I will need some help landing this one. I'm not a C++ pro, yet.

I would like to gain access to the session user inbox playlist via sp_session_inbox_create. Copying the way that sp_session_starred_for_user_create turns into the starredPlaylist accessor was the easiest for me.

I know that casting it to a StarredPlaylist isn't correct, nor is having it on User, when it only makes sense for a session user.
